### PR TITLE
chore(release): 1.5.0

### DIFF
--- a/.github/workflows/build-site-index.yml
+++ b/.github/workflows/build-site-index.yml
@@ -1,0 +1,52 @@
+name: Build Docs Site Index
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  build-site-index:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --all-groups
+
+      - name: Build docs index
+        run: >
+          uv run python -m documentation_search_enhanced.site_index_builder
+          --output docs_site_index.json
+          --gzip
+          --sitemap missing
+          --max-sitemap-urls 5000
+          --max-concurrency 6
+
+      - name: Upload workflow artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site-index
+          path: |
+            docs_site_index.json
+            docs_site_index.json.gz
+
+      - name: Upload release assets
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            docs_site_index.json
+            docs_site_index.json.gz
+

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ DYNAMIC_CONFIG_ANALYSIS.md
 HYBRID_SETUP_GUIDE.md
 TECHNICAL_DEEP_DIVE.md
 TEST_CURSOR_INTEGRATION.md
+
+# Generated docs site index assets
+docs_site_index.json
+docs_site_index.json.gz
+docs_site_index.json.docs_site_index.json.gz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ## Build, Test, and Development Commands
 - Install deps: `uv sync` (includes dev extras).
-- Run MCP server: `uv run python src/documentation_search_enhanced/main.py` (requires `.env` with `SERPER_API_KEY`).
+- Run MCP server: `uv run python src/documentation_search_enhanced/main.py` (optional: set `SERPER_API_KEY` for Serper-powered search).
 - Test: `uv run pytest`.
 - Lint/format: `uv run ruff check src`, `uv run black src`.
 - Build/publish: `uv build`, `publish_to_pypi.sh`.
@@ -27,7 +27,6 @@
 - PRs: link issues, summarize changes, list validation commands run (`uv run pytest`, linting), update `CHANGELOG.md` for user‑visible changes, attach screenshots/JSON when modifying tool output.
 
 ## Security & Configuration Tips
-- Never commit secrets; load via `.env` (e.g., `SERPER_API_KEY`).
+- Never commit secrets; load via `.env` (e.g., optional `SERPER_API_KEY`).
 - After editing `config.json`, validate: `uv run python src/documentation_search_enhanced/config_validator.py`.
 - Document new env vars in `README.md`; scope and rotate keys if exposure is suspected.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Documentation Search Enhanced MCP Server will be documented in this file.
 
+## [Unreleased]
+
+## [1.5.0] - 2025-12-17
+
+### Added
+- GitHub Release assets `docs_site_index.json` and `docs_site_index.json.gz` for Serper-free docs search.
+- Auto-download support for the prebuilt index (env: `DOCS_SITE_INDEX_AUTO_DOWNLOAD`, `DOCS_SITE_INDEX_MAX_AGE_HOURS`, `DOCS_SITE_INDEX_URL(S)`, `DOCS_SITE_INDEX_PATH`).
+- CI workflow to build and upload the index on release publish.
+- HTML link discovery fallback for docs sites without sitemaps/indexes (e.g. `react.dev`).
+
+### Changed
+- `SERPER_API_KEY` is now optional; when unset, documentation search uses a prebuilt docs index (auto-downloaded from GitHub Releases on startup) plus on-site docs search (MkDocs/Sphinx indexes when available).
+- Serper-free sitemap search now prefers live sitemap refreshes when available, falling back to the prebuilt index (and HTML link discovery for sites without sitemaps, e.g. `react.dev`).
+- Playwright scraping now falls back to `httpx` when Playwright cannot launch (common in sandboxed environments).
+- Improved Codex CLI reliability: avoid stdio handshake stalls and reduce default startup output noise.
+
 ## [1.4.1] - 2025-12-16
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,9 +61,9 @@ Ready to dive into the code?
 ## 🛠️ Development Setup
 
 ### **Prerequisites**
-- Python 3.8+
+- Python 3.12+
 - UV package manager (recommended)
-- Serper API key (free at serper.dev)
+- Optional: Serper API key (free at serper.dev)
 
 ### **Setup Steps**
 ```bash
@@ -75,7 +75,8 @@ cd documentation-search-mcp
 uv sync
 
 # 3. Set up environment
-echo "SERPER_API_KEY=your_key_here" > .env
+# Optional: enable Serper-powered search
+# echo "SERPER_API_KEY=your_key_here" > .env
 
 # 4. Test the setup
 python src/documentation_search_enhanced/main.py

--- a/README.md
+++ b/README.md
@@ -25,34 +25,36 @@ Configure your assistant to launch the server:
   "mcpServers": {
     "documentation-search-enhanced": {
       "command": "uvx",
-      "args": ["documentation-search-enhanced@latest"],
-      "env": { "SERPER_API_KEY": "your_serper_api_key_here" }
+      "args": ["documentation-search-enhanced@latest"]
     }
   }
 }
 ```
+No API key is required. Optionally set `SERPER_API_KEY` to use Serper-powered search.
+Without it, the server uses a prebuilt docs index (auto-downloaded from GitHub Releases on startup) plus on-site docs search (MkDocs/Sphinx indexes when available).
+Control the download with `DOCS_SITE_INDEX_AUTO_DOWNLOAD`, `DOCS_SITE_INDEX_MAX_AGE_HOURS`, `DOCS_SITE_INDEX_URL(S)`, and `DOCS_SITE_INDEX_PATH`.
+Set `server_config.features.real_time_search=false` to avoid any live crawling and rely only on the downloaded index.
 The process stays running and listens for JSON-RPC calls; stop it with `Ctrl+C` when finished.
 
 ## Codex CLI
 Add the server using Codex’s built-in MCP manager:
 ```bash
 codex mcp add documentation-search-enhanced \
-  --env SERPER_API_KEY=your_serper_api_key_here \
   -- uvx documentation-search-enhanced@latest
 ```
 To run from a local checkout instead:
 ```bash
 codex mcp add documentation-search-enhanced \
-  --env SERPER_API_KEY=your_serper_api_key_here \
   -- uv run python src/documentation_search_enhanced/main.py
 ```
 
 ## Development Workflow
 ```bash
-git clone https://github.com/antonmishel/documentation-search-mcp.git
+git clone https://github.com/anton-prosterity/documentation-search-mcp.git
 cd documentation-search-mcp
 uv sync --all-extras --all-groups  # include dev tools
-echo "SERPER_API_KEY=your_key_here" > .env
+# Optional: enable Serper-powered search
+# echo "SERPER_API_KEY=your_key_here" > .env
 uv run python src/documentation_search_enhanced/main.py
 ```
 - Run core tests: `uv run pytest --ignore=pytest-test-project`.

--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,7 @@
 import os
 import sys
 
-# Ensure example test projects can import their local modules when pytest is run
-# from the repository root.
-EXAMPLE_ROOTS = ["pytest-test-project"]
-
-for folder in EXAMPLE_ROOTS:
-    path = os.path.join(os.path.dirname(__file__), folder)
-    if os.path.isdir(path) and path not in sys.path:
-        sys.path.insert(0, path)
+ROOT = os.path.dirname(__file__)
+SRC = os.path.join(ROOT, "src")
+if os.path.isdir(SRC) and SRC not in sys.path:
+    sys.path.insert(0, SRC)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "documentation-search-enhanced"
-version = "1.4.1"
+version = "1.5.0"
 description = "Enhanced MCP server for searching documentation with OSINT vulnerability scanning, security analysis, and AWS-style deployment"
 readme = "README.md"
 license = "MIT"
@@ -35,9 +35,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/antonmishel/documentation-search-mcp"
-Repository = "https://github.com/antonmishel/documentation-search-mcp"
-Issues = "https://github.com/antonmishel/documentation-search-mcp/issues"
+Homepage = "https://github.com/anton-prosterity/documentation-search-mcp"
+Repository = "https://github.com/anton-prosterity/documentation-search-mcp"
+Issues = "https://github.com/anton-prosterity/documentation-search-mcp/issues"
 
 [project.scripts]
 documentation-search-enhanced = "documentation_search_enhanced.main:main"
@@ -65,4 +65,18 @@ include = [
 [dependency-groups]
 dev = [
     "twine>=6.1.0",
+]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra"
+norecursedirs = [
+    ".git",
+    ".venv",
+    ".uv-cache",
+    "build",
+    "dist",
+    "pytest-test-project",
+    "samples",
+    "my-test-fastapi-app",
 ]

--- a/samples/README.md
+++ b/samples/README.md
@@ -2,6 +2,8 @@
 
 This directory contains ready-to-use examples showing how to integrate and use the documentation-search-enhanced MCP server with different AI assistants and workflows.
 
+No API key is required by default. If you want Serper-powered search, set `SERPER_API_KEY`; otherwise the server uses a prebuilt docs index (auto-downloaded from GitHub Releases on startup) plus on-site docs search (MkDocs/Sphinx indexes when available).
+
 ## 📁 Sample Configurations
 
 ### 🎯 **Basic Setup Examples**
@@ -14,7 +16,6 @@ This directory contains ready-to-use examples showing how to integrate and use t
       "command": "uvx",
       "args": ["documentation-search-enhanced@latest"],
       "env": {
-        "SERPER_API_KEY": "your_key_here",
         "FASTMCP_LOG_LEVEL": "INFO"
       }
     }
@@ -30,7 +31,6 @@ This directory contains ready-to-use examples showing how to integrate and use t
       "command": "uvx",
       "args": ["documentation-search-enhanced@latest"],
       "env": {
-        "SERPER_API_KEY": "your_key_here",
         "FASTMCP_LOG_LEVEL": "ERROR"
       },
       "disabled": false,
@@ -43,7 +43,6 @@ This directory contains ready-to-use examples showing how to integrate and use t
 #### For Codex CLI
 ```bash
 codex mcp add documentation-search-enhanced \
-  --env SERPER_API_KEY=your_key_here \
   --env FASTMCP_LOG_LEVEL=ERROR \
   -- uvx documentation-search-enhanced@latest
 ```
@@ -58,7 +57,6 @@ codex mcp add documentation-search-enhanced \
       "command": "uvx",
       "args": ["documentation-search-enhanced@latest"],
       "env": {
-        "SERPER_API_KEY": "your_production_key",
         "FASTMCP_LOG_LEVEL": "ERROR",
         "GITHUB_TOKEN": "your_github_token_optional"
       },
@@ -81,7 +79,6 @@ codex mcp add documentation-search-enhanced \
       "command": "uvx",
       "args": ["documentation-search-enhanced@latest"],
       "env": {
-        "SERPER_API_KEY": "your_dev_key",
         "FASTMCP_LOG_LEVEL": "DEBUG"
       },
       "disabled": false,
@@ -191,10 +188,7 @@ app.add_middleware(
         "mcp.servers": {
           "documentation-search-enhanced": {
             "command": "uvx",
-            "args": ["documentation-search-enhanced@latest"],
-            "env": {
-              "SERPER_API_KEY": "${env:SERPER_API_KEY}"
-            }
+            "args": ["documentation-search-enhanced@latest"]
           }
         }
       }
@@ -213,7 +207,6 @@ RUN pip install uv
 # Install MCP server
 RUN uvx documentation-search-enhanced@latest
 
-ENV SERPER_API_KEY=""
 ENV FASTMCP_LOG_LEVEL="INFO"
 
 CMD ["uvx", "documentation-search-enhanced@latest"]
@@ -221,9 +214,9 @@ CMD ["uvx", "documentation-search-enhanced@latest"]
 
 ## 🎯 **Best Practices**
 
-### 1. **API Key Management**
+### 1. **Optional Serper API Key**
 ```bash
-# Use environment variables
+# Enable Serper-powered search (optional)
 export SERPER_API_KEY="your_key_here"
 
 # Or use .env files for local development

--- a/src/documentation_search_enhanced/__init__.py
+++ b/src/documentation_search_enhanced/__init__.py
@@ -5,7 +5,7 @@ An enhanced Model Context Protocol (MCP) server for searching documentation
 across popular libraries with caching, real-time web search, and library insights.
 """
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 __author__ = "Anton Mishel"
 __email__ = "your-email@example.com"
 

--- a/src/documentation_search_enhanced/config.json
+++ b/src/documentation_search_enhanced/config.json
@@ -1,8 +1,8 @@
 {
-    "version": "1.4.1",
+    "version": "1.5.0",
     "server_config": {
         "name": "documentation-search-enhanced",
-        "version": "1.4.1",
+        "version": "1.5.0",
         "logging_level": "INFO",
         "max_concurrent_requests": 10,
         "request_timeout_seconds": 30,

--- a/src/documentation_search_enhanced/site_index_builder.py
+++ b/src/documentation_search_enhanced/site_index_builder.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Build a preindexed docs site index for Serper-free search.
+
+This module is used by CI to generate `docs_site_index.json` (+ optional `.gz`) assets
+that are published to GitHub Releases and auto-downloaded by the server at startup.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import argparse
+import gzip
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Iterable, Mapping, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+from . import site_search
+
+
+@dataclass(frozen=True)
+class SiteIndexBuildSettings:
+    user_agent: str
+    max_concurrent_sites: int = 5
+    sitemap_mode: str = "missing"  # none|missing|all
+    max_sitemap_urls: int = 5_000
+    timeout_seconds: float = 60.0
+
+
+def load_docs_urls_from_config(config_path: str) -> Dict[str, str]:
+    if not config_path:
+        raise ValueError("config_path must be non-empty")
+    with open(config_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    raw = data.get("docs_urls", {})
+    if not isinstance(raw, dict):
+        return {}
+
+    docs_urls: Dict[str, str] = {}
+    for name, value in raw.items():
+        if not isinstance(name, str):
+            continue
+        if isinstance(value, dict):
+            url = str(value.get("url") or "").strip()
+        else:
+            url = str(value or "").strip()
+        if url:
+            docs_urls[name] = url
+    return docs_urls
+
+
+def _parse_libraries(value: Optional[str]) -> Optional[list[str]]:
+    if not value:
+        return None
+    parts = [part.strip() for part in value.split(",")]
+    libraries = [part for part in parts if part]
+    return libraries or None
+
+
+def _origin_from_url(url: str) -> Optional[str]:
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+async def build_site_index_file(
+    docs_urls: Mapping[str, str],
+    *,
+    output_path: str,
+    gzip_output: bool,
+    settings: SiteIndexBuildSettings,
+    client: Optional[httpx.AsyncClient] = None,
+) -> Dict[str, Any]:
+    if not output_path:
+        raise ValueError("output_path must be non-empty")
+
+    if settings.sitemap_mode not in {"none", "missing", "all"}:
+        raise ValueError("sitemap_mode must be one of: none, missing, all")
+
+    site_search._sitemap_cache.clear()
+    site_search._sitemap_locks.clear()
+    site_search._index_cache.clear()
+    site_search._index_locks.clear()
+
+    original_max_sitemap_urls = getattr(site_search, "_MAX_SITEMAP_URLS", None)
+    if settings.max_sitemap_urls and settings.max_sitemap_urls > 0:
+        site_search._MAX_SITEMAP_URLS = int(settings.max_sitemap_urls)
+
+    created_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(timeout=httpx.Timeout(settings.timeout_seconds))
+
+    try:
+        concurrency = max(1, min(int(settings.max_concurrent_sites), 20))
+        semaphore = asyncio.Semaphore(concurrency)
+
+        results: list[dict[str, Any]] = []
+
+        async def run_one(library: str, url: str) -> None:
+            async with semaphore:
+                summary = await site_search.preindex_site(
+                    url,
+                    client,
+                    user_agent=settings.user_agent,
+                    include_sitemap=False,
+                )
+
+                has_index = bool(
+                    summary.get("mkdocs_index") or summary.get("sphinx_index")
+                )
+                include_sitemap = settings.sitemap_mode == "all" or (
+                    settings.sitemap_mode == "missing" and not has_index
+                )
+                if include_sitemap:
+                    origin = summary.get("origin") or _origin_from_url(url)
+                    try:
+                        urls = await site_search._load_site_sitemap_urls(  # type: ignore[attr-defined]
+                            client,
+                            url,
+                            user_agent=settings.user_agent,
+                        )
+                    except Exception as e:
+                        summary.setdefault("errors", []).append(f"sitemap:{e}")
+                    else:
+                        if origin and urls:
+                            site_search._sitemap_cache[origin] = (
+                                site_search._SitemapCacheEntry(  # type: ignore[attr-defined]
+                                    fetched_at=datetime.now(),
+                                    urls=tuple(urls),
+                                )
+                            )
+                            summary["sitemap"] = {"urls": len(urls)}
+
+                summary["library"] = library
+                results.append(summary)
+
+        tasks = [
+            run_one(library, url)
+            for library, url in sorted(docs_urls.items(), key=lambda item: item[0])
+            if url
+        ]
+        if tasks:
+            await asyncio.gather(*tasks)
+
+        site_search.save_preindexed_state(output_path)
+
+        gz_path: Optional[str] = None
+        if gzip_output:
+            gz_path = f"{output_path}.gz"
+            with open(output_path, "rb") as fh:
+                blob = fh.read()
+            with gzip.open(gz_path, "wb", compresslevel=9) as fh:
+                fh.write(blob)
+
+        indexed_sites = sum(
+            1
+            for summary in results
+            if summary.get("mkdocs_index")
+            or summary.get("sphinx_index")
+            or summary.get("sitemap")
+        )
+
+        return {
+            "status": "ok" if indexed_sites else "error",
+            "output_path": output_path,
+            "gzip_path": gz_path,
+            "total_libraries": len(docs_urls),
+            "indexed_libraries": indexed_sites,
+            "results": sorted(results, key=lambda item: str(item.get("library") or "")),
+        }
+    finally:
+        if original_max_sitemap_urls is not None:
+            site_search._MAX_SITEMAP_URLS = original_max_sitemap_urls
+        if created_client:
+            await client.aclose()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build docs_site_index.json for releases."
+    )
+    parser.add_argument(
+        "--config",
+        default=os.path.join("src", "documentation_search_enhanced", "config.json"),
+        help="Path to config.json (default: bundled src config).",
+    )
+    parser.add_argument(
+        "--output",
+        default="docs_site_index.json",
+        help="Path to write the index JSON (default: docs_site_index.json).",
+    )
+    parser.add_argument(
+        "--gzip",
+        action="store_true",
+        help="Also write a .gz next to the JSON file.",
+    )
+    parser.add_argument(
+        "--libraries",
+        default=None,
+        help="Comma-separated list of libraries to index (default: all).",
+    )
+    parser.add_argument(
+        "--sitemap",
+        choices=("none", "missing", "all"),
+        default="missing",
+        help="Whether to include sitemap URLs: none, missing, or all (default: missing).",
+    )
+    parser.add_argument(
+        "--max-sitemap-urls",
+        type=int,
+        default=5_000,
+        help="Max sitemap URLs per site when included (default: 5000).",
+    )
+    parser.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=5,
+        help="Max concurrent sites to index (default: 5).",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=60.0,
+        help="HTTP timeout (default: 60s).",
+    )
+    parser.add_argument(
+        "--user-agent",
+        default="documentation-search-enhanced/index-builder",
+        help="User-Agent header to use for fetches.",
+    )
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+
+    docs_urls = load_docs_urls_from_config(args.config)
+    libraries = _parse_libraries(args.libraries)
+    if libraries:
+        docs_urls = {lib: docs_urls[lib] for lib in libraries if lib in docs_urls}
+
+    settings = SiteIndexBuildSettings(
+        user_agent=args.user_agent,
+        max_concurrent_sites=args.max_concurrency,
+        sitemap_mode=args.sitemap,
+        max_sitemap_urls=args.max_sitemap_urls,
+        timeout_seconds=args.timeout_seconds,
+    )
+
+    if not docs_urls:
+        print("No documentation sources found to index.", file=sys.stderr)
+        return 2
+
+    result = asyncio.run(
+        build_site_index_file(
+            docs_urls,
+            output_path=args.output,
+            gzip_output=bool(args.gzip),
+            settings=settings,
+        )
+    )
+    print(json.dumps(result, indent=2, sort_keys=True), file=sys.stderr)
+    return 0 if result.get("status") == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/documentation_search_enhanced/site_index_downloader.py
+++ b/src/documentation_search_enhanced/site_index_downloader.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Download and manage the prebuilt docs site index.
+
+The server can operate without Serper by using docs-native search indexes (MkDocs/Sphinx)
+and/or a prebuilt index file. This module implements an optional auto-download flow
+from GitHub Releases to keep that prebuilt index up to date without requiring users
+to run any indexing commands.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+import httpx
+
+
+DEFAULT_RELEASE_REPO = "anton-prosterity/documentation-search-mcp"
+DEFAULT_RELEASE_ASSET_BASENAME = "docs_site_index.json"
+DEFAULT_RELEASE_URLS = (
+    f"https://github.com/{DEFAULT_RELEASE_REPO}/releases/latest/download/{DEFAULT_RELEASE_ASSET_BASENAME}.gz",
+    f"https://github.com/{DEFAULT_RELEASE_REPO}/releases/latest/download/{DEFAULT_RELEASE_ASSET_BASENAME}",
+)
+
+
+@dataclass(frozen=True)
+class SiteIndexDownloadSettings:
+    path: str
+    urls: Tuple[str, ...] = DEFAULT_RELEASE_URLS
+    auto_download: bool = True
+    max_age_hours: int = 24 * 7
+
+
+def _parse_bool(value: Optional[str], *, default: bool) -> bool:
+    if value is None:
+        return default
+    value = value.strip().lower()
+    if value in {"1", "true", "yes", "y", "on"}:
+        return True
+    if value in {"0", "false", "no", "n", "off"}:
+        return False
+    return default
+
+
+def _parse_int(value: Optional[str], *, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value.strip())
+    except ValueError:
+        return default
+
+
+def _split_urls(value: Optional[str]) -> Tuple[str, ...]:
+    if not value:
+        return ()
+    parts = [part.strip() for part in value.split(",")]
+    return tuple(part for part in parts if part)
+
+
+def _default_cache_dir() -> Path:
+    xdg_cache = os.getenv("XDG_CACHE_HOME")
+    if xdg_cache:
+        return Path(xdg_cache)
+    home = os.path.expanduser("~")
+    if home and home != "~":
+        return Path(home) / ".cache"
+    return Path(os.getcwd())
+
+
+def default_site_index_path(*, cwd: Optional[str] = None) -> str:
+    """Choose a reasonable default path for the prebuilt index file."""
+    cwd_path = Path(cwd or os.getcwd()) / ".docs_site_index.json"
+    if cwd_path.exists():
+        return str(cwd_path)
+
+    cache_dir = _default_cache_dir() / "documentation-search-enhanced"
+    return str(cache_dir / "docs_site_index.json")
+
+
+def load_site_index_settings_from_env(
+    *, cwd: Optional[str] = None
+) -> SiteIndexDownloadSettings:
+    """Load site index settings from environment variables."""
+    path = os.getenv("DOCS_SITE_INDEX_PATH") or default_site_index_path(cwd=cwd)
+
+    urls = _split_urls(os.getenv("DOCS_SITE_INDEX_URLS"))
+    if not urls:
+        url = os.getenv("DOCS_SITE_INDEX_URL")
+        urls = (url.strip(),) if url and url.strip() else DEFAULT_RELEASE_URLS
+
+    auto_download = _parse_bool(
+        os.getenv("DOCS_SITE_INDEX_AUTO_DOWNLOAD"), default=True
+    )
+    max_age_hours = _parse_int(
+        os.getenv("DOCS_SITE_INDEX_MAX_AGE_HOURS"), default=24 * 7
+    )
+
+    return SiteIndexDownloadSettings(
+        path=path,
+        urls=urls,
+        auto_download=auto_download,
+        max_age_hours=max_age_hours,
+    )
+
+
+def should_download_site_index(path: str, *, max_age_hours: int) -> bool:
+    """Return True when the on-disk index is missing or older than max_age_hours."""
+    if not path:
+        return False
+    target = Path(path)
+    if not target.exists():
+        return True
+
+    if max_age_hours <= 0:
+        return True
+
+    try:
+        mtime = datetime.fromtimestamp(target.stat().st_mtime)
+    except Exception:
+        return True
+    return datetime.now() - mtime > timedelta(hours=max_age_hours)
+
+
+def _maybe_decompress_gzip(blob: bytes) -> bytes:
+    if len(blob) >= 2 and blob[0] == 0x1F and blob[1] == 0x8B:
+        return gzip.decompress(blob)
+    return blob
+
+
+def _validate_index_payload(payload: Any) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError("Index file must be a JSON object")
+    schema_version = payload.get("schema_version")
+    if schema_version != 1:
+        raise ValueError(f"Unsupported index schema_version: {schema_version!r}")
+    if "indexes" not in payload and "sitemaps" not in payload:
+        raise ValueError("Index file missing expected keys")
+    return payload
+
+
+async def download_site_index(
+    client: httpx.AsyncClient,
+    *,
+    urls: Sequence[str],
+    dest_path: str,
+    user_agent: str,
+    timeout_seconds: float = 60.0,
+) -> Dict[str, Any]:
+    """Download the latest index from the first working URL and save it to dest_path."""
+    if not dest_path:
+        return {"status": "error", "error": "dest_path is empty"}
+
+    errors: list[str] = []
+    headers = {"User-Agent": user_agent}
+
+    for url in urls:
+        try:
+            response = await client.get(
+                url,
+                headers=headers,
+                timeout=httpx.Timeout(timeout_seconds),
+                follow_redirects=True,
+            )
+            if response.status_code == 404:
+                errors.append(f"{url}: 404")
+                continue
+            response.raise_for_status()
+
+            blob = _maybe_decompress_gzip(response.content)
+            payload = json.loads(blob.decode("utf-8"))
+            _validate_index_payload(payload)
+
+            target = Path(dest_path)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = target.with_suffix(target.suffix + ".tmp")
+            tmp_path.write_bytes(blob)
+            tmp_path.replace(target)
+
+            return {
+                "status": "downloaded",
+                "url": url,
+                "bytes": len(blob),
+            }
+        except Exception as e:
+            errors.append(f"{url}: {e}")
+
+    return {"status": "error", "errors": errors}
+
+
+async def ensure_site_index_file(
+    client: httpx.AsyncClient,
+    *,
+    settings: SiteIndexDownloadSettings,
+    user_agent: str,
+) -> Dict[str, Any]:
+    """Ensure a reasonably fresh site index exists on disk (download if needed)."""
+    if not settings.auto_download:
+        return {
+            "status": "skipped",
+            "reason": "auto_download disabled",
+            "path": settings.path,
+        }
+
+    if not should_download_site_index(
+        settings.path, max_age_hours=settings.max_age_hours
+    ):
+        return {"status": "ok", "reason": "up_to_date", "path": settings.path}
+
+    result = await download_site_index(
+        client,
+        urls=settings.urls,
+        dest_path=settings.path,
+        user_agent=user_agent,
+    )
+    result["path"] = settings.path
+    return result

--- a/src/documentation_search_enhanced/site_search.py
+++ b/src/documentation_search_enhanced/site_search.py
@@ -1,0 +1,1325 @@
+#!/usr/bin/env python3
+"""
+Serper-free documentation site search.
+
+This module provides a Serper-free fallback for `site:` queries by:
+
+1) Preferring docs-native search indexes when available (MkDocs / Sphinx)
+2) Falling back to sitemap discovery (robots.txt + sitemap.xml)
+3) Optionally using a Playwright-backed fetcher to score/snippet page content
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import json
+import os
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+)
+from urllib.parse import urljoin, urlparse
+
+import httpx
+from bs4 import BeautifulSoup
+
+
+_SITEMAP_CACHE_TTL = timedelta(hours=24)
+_INDEX_CACHE_TTL = timedelta(hours=24)
+_MAX_SITEMAP_URLS = 50_000
+_MAX_SITEMAPS_TO_FETCH = 12
+_MAX_INDEX_BYTES = 10_000_000
+_MAX_INDEX_DOC_TEXT_CHARS = 5_000
+_DEFAULT_CONTENT_FETCH_CONCURRENCY = 3
+
+
+@dataclass(frozen=True)
+class _SitemapCacheEntry:
+    fetched_at: datetime
+    urls: Tuple[str, ...]
+
+
+_sitemap_cache: Dict[str, _SitemapCacheEntry] = {}
+_sitemap_locks: Dict[str, asyncio.Lock] = {}
+
+
+@dataclass(frozen=True)
+class _IndexCacheEntry:
+    fetched_at: datetime
+    kind: str
+    payload: Any
+
+
+_index_cache: Dict[str, _IndexCacheEntry] = {}
+_index_locks: Dict[str, asyncio.Lock] = {}
+
+
+def _parse_iso_datetime(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is not None:
+        try:
+            parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+        except Exception:
+            parsed = parsed.replace(tzinfo=None)
+    return parsed
+
+
+def export_preindexed_state() -> Dict[str, Any]:
+    """Export in-memory sitemap/index caches for persistence."""
+    now = datetime.now()
+    sitemaps: Dict[str, Dict[str, Any]] = {}
+    for origin, entry in _sitemap_cache.items():
+        sitemaps[origin] = {
+            "fetched_at": entry.fetched_at.isoformat(),
+            "urls": list(entry.urls),
+        }
+
+    indexes: Dict[str, Dict[str, Any]] = {}
+    for index_url, entry in _index_cache.items():
+        payload = entry.payload
+        if isinstance(payload, tuple):
+            payload = list(payload)
+
+        indexes[index_url] = {
+            "fetched_at": entry.fetched_at.isoformat(),
+            "kind": entry.kind,
+            "payload": payload,
+        }
+
+    return {
+        "schema_version": 1,
+        "generated_at": now.isoformat(),
+        "sitemaps": sitemaps,
+        "indexes": indexes,
+    }
+
+
+def import_preindexed_state(state: Any) -> None:
+    """Import previously persisted sitemap/index caches."""
+    if not isinstance(state, dict):
+        return
+
+    imported_at = datetime.now()
+    max_future_skew = timedelta(days=1)
+
+    sitemaps = state.get("sitemaps")
+    if isinstance(sitemaps, dict):
+        for origin, entry in sitemaps.items():
+            if not isinstance(origin, str) or not isinstance(entry, dict):
+                continue
+            urls_raw = entry.get("urls")
+            if not isinstance(urls_raw, list):
+                continue
+            urls = tuple(str(url).strip() for url in urls_raw if str(url).strip())
+            if not urls:
+                continue
+            fetched_at = _parse_iso_datetime(entry.get("fetched_at"))
+            if fetched_at is None or fetched_at > imported_at + max_future_skew:
+                fetched_at = imported_at
+            _sitemap_cache[origin] = _SitemapCacheEntry(
+                fetched_at=fetched_at, urls=urls
+            )
+
+    indexes = state.get("indexes")
+    if isinstance(indexes, dict):
+        for index_url, entry in indexes.items():
+            if not isinstance(index_url, str) or not isinstance(entry, dict):
+                continue
+            kind = entry.get("kind")
+            payload_raw = entry.get("payload")
+            if not isinstance(kind, str):
+                continue
+
+            if kind == "mkdocs":
+                if not isinstance(payload_raw, list):
+                    continue
+                prepared = []
+                for doc in payload_raw:
+                    if not isinstance(doc, dict):
+                        continue
+                    location = str(doc.get("location") or "").strip()
+                    if not location:
+                        continue
+                    title = str(doc.get("title") or "").strip()
+                    text = str(doc.get("text") or "").strip()
+                    if len(text) > _MAX_INDEX_DOC_TEXT_CHARS:
+                        text = text[:_MAX_INDEX_DOC_TEXT_CHARS]
+                    prepared.append(
+                        {"location": location, "title": title, "text": text}
+                    )
+                if not prepared:
+                    continue
+                payload: Any = tuple(prepared)
+            elif kind == "sphinx":
+                if not isinstance(payload_raw, dict):
+                    continue
+                payload = payload_raw
+            else:
+                continue
+
+            fetched_at = _parse_iso_datetime(entry.get("fetched_at"))
+            if fetched_at is None or fetched_at > imported_at + max_future_skew:
+                fetched_at = imported_at
+
+            _index_cache[index_url] = _IndexCacheEntry(
+                fetched_at=fetched_at, kind=kind, payload=payload
+            )
+
+
+def load_preindexed_state(path: str) -> bool:
+    """Load a persisted index cache from disk into memory."""
+    if not path:
+        return False
+    if not os.path.exists(path):
+        return False
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except Exception:
+        return False
+    import_preindexed_state(raw)
+    return True
+
+
+def save_preindexed_state(path: str) -> None:
+    """Persist current in-memory sitemap/index caches to disk."""
+    if not path:
+        raise ValueError("persist path must be non-empty")
+    state = export_preindexed_state()
+    tmp_path = f"{path}.tmp"
+    with open(tmp_path, "w", encoding="utf-8") as fh:
+        json.dump(state, fh)
+    os.replace(tmp_path, path)
+
+
+def _get_cached_index_from_memory(index_url: str, *, kind: str) -> Optional[Any]:
+    cache_entry = _index_cache.get(index_url)
+    if cache_entry and cache_entry.kind == kind:
+        return cache_entry.payload
+    return None
+
+
+def _get_cached_sitemap_urls_from_memory(
+    origin: str, *, allow_stale: bool
+) -> Optional[List[str]]:
+    cache_entry = _sitemap_cache.get(origin)
+    if not cache_entry:
+        return None
+    if not cache_entry.urls:
+        return None
+    if allow_stale:
+        return list(cache_entry.urls)
+    if datetime.now() - cache_entry.fetched_at <= _SITEMAP_CACHE_TTL:
+        return list(cache_entry.urls)
+    return None
+
+
+async def preindex_site(
+    site_url: str,
+    client: httpx.AsyncClient,
+    *,
+    user_agent: str,
+    include_sitemap: bool = False,
+) -> Dict[str, Any]:
+    """Fetch and cache on-site search indexes for a docs site."""
+    parsed = urlparse(site_url)
+    if not parsed.scheme or not parsed.netloc:
+        return {"site_url": site_url, "status": "invalid_url"}
+
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    results: Dict[str, Any] = {
+        "site_url": site_url,
+        "origin": origin,
+        "mkdocs_index": None,
+        "sphinx_index": None,
+        "sitemap": None,
+        "errors": [],
+    }
+
+    for index_url in _mkdocs_index_candidates(site_url):
+        try:
+            docs = await _get_cached_index(
+                client,
+                index_url,
+                user_agent=user_agent,
+                kind="mkdocs",
+                timeout_seconds=20.0,
+            )
+        except Exception as e:
+            results["errors"].append(f"mkdocs:{index_url}: {e}")
+            continue
+        if docs:
+            results["mkdocs_index"] = {"index_url": index_url, "documents": len(docs)}
+            break
+
+    for index_url in _sphinx_index_candidates(site_url):
+        try:
+            index = await _get_cached_index(
+                client,
+                index_url,
+                user_agent=user_agent,
+                kind="sphinx",
+                timeout_seconds=20.0,
+            )
+        except Exception as e:
+            results["errors"].append(f"sphinx:{index_url}: {e}")
+            continue
+        if isinstance(index, dict):
+            filenames = index.get("filenames")
+            results["sphinx_index"] = {
+                "index_url": index_url,
+                "documents": len(filenames) if isinstance(filenames, list) else None,
+            }
+            break
+
+    if include_sitemap:
+        try:
+            urls = await _load_site_sitemap_urls(
+                client, site_url, user_agent=user_agent
+            )
+            if urls:
+                _sitemap_cache[origin] = _SitemapCacheEntry(
+                    fetched_at=datetime.now(), urls=tuple(urls)
+                )
+                results["sitemap"] = {"urls": len(urls)}
+        except Exception as e:
+            results["errors"].append(f"sitemap:{origin}: {e}")
+
+    results["status"] = (
+        "ok"
+        if results.get("mkdocs_index")
+        or results.get("sphinx_index")
+        or results.get("sitemap")
+        else "no_index_found"
+    )
+    return results
+
+
+def _parse_site_query(query: str) -> Tuple[Optional[str], str]:
+    match = re.search(r"\bsite:(\S+)", query)
+    if not match:
+        return None, query.strip()
+
+    site_token = match.group(1).strip().strip('"').strip("'")
+    remaining = (query[: match.start()] + query[match.end() :]).strip()
+    return site_token, remaining
+
+
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "for",
+    "from",
+    "how",
+    "in",
+    "into",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "that",
+    "the",
+    "these",
+    "this",
+    "to",
+    "using",
+    "what",
+    "when",
+    "where",
+    "why",
+    "with",
+}
+
+
+def _tokenize_query(text: str) -> List[str]:
+    tokens = [t for t in re.findall(r"[a-z0-9]+", text.lower()) if t]
+    filtered: List[str] = []
+    for token in tokens:
+        if token in _STOPWORDS:
+            continue
+        if len(token) <= 1:
+            continue
+        if token not in filtered:
+            filtered.append(token)
+    return filtered[:12]
+
+
+def _matches_site_prefix(candidate_url: str, site_url: str) -> bool:
+    try:
+        candidate = urlparse(candidate_url)
+        site = urlparse(site_url)
+    except Exception:
+        return False
+
+    if not candidate.netloc or candidate.netloc.lower() != site.netloc.lower():
+        return False
+
+    site_path = site.path or "/"
+    candidate_path = candidate.path or "/"
+
+    site_path_norm = site_path.rstrip("/")
+    candidate_path_norm = candidate_path.rstrip("/")
+
+    if site_path_norm in ("", "/"):
+        return True
+
+    return candidate_path_norm == site_path_norm or candidate_path_norm.startswith(
+        f"{site_path_norm}/"
+    )
+
+
+def _sitemap_candidates(site_url: str) -> List[str]:
+    parsed = urlparse(site_url)
+    if not parsed.scheme or not parsed.netloc:
+        return []
+
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    site_base = site_url.rstrip("/")
+
+    candidates = [
+        f"{origin}/sitemap.xml",
+        f"{origin}/sitemap_index.xml",
+        f"{origin}/sitemap-index.xml",
+    ]
+
+    if site_base != origin:
+        candidates.extend(
+            [
+                f"{site_base}/sitemap.xml",
+                f"{site_base}/sitemap_index.xml",
+            ]
+        )
+
+    # Deduplicate while preserving order.
+    seen = set()
+    unique: List[str] = []
+    for item in candidates:
+        if item not in seen:
+            unique.append(item)
+            seen.add(item)
+    return unique
+
+
+def _mkdocs_index_candidates(site_url: str) -> List[str]:
+    parsed = urlparse(site_url)
+    if not parsed.scheme or not parsed.netloc:
+        return []
+
+    origin = f"{parsed.scheme}://{parsed.netloc}/"
+    base = site_url.rstrip("/") + "/"
+
+    candidates = [
+        urljoin(base, "search/search_index.json"),
+        urljoin(base, "search_index.json"),
+    ]
+    if base != origin:
+        candidates.extend(
+            [
+                urljoin(origin, "search/search_index.json"),
+                urljoin(origin, "search_index.json"),
+            ]
+        )
+
+    seen: set[str] = set()
+    unique: List[str] = []
+    for item in candidates:
+        if item not in seen:
+            unique.append(item)
+            seen.add(item)
+    return unique
+
+
+def _mkdocs_base_from_index_url(index_url: str) -> str:
+    suffixes = ("/search/search_index.json", "/search_index.json")
+    for suffix in suffixes:
+        if index_url.endswith(suffix):
+            return index_url[: -len(suffix)] + "/"
+    return urljoin(index_url, "./")
+
+
+def _sphinx_index_candidates(site_url: str) -> List[str]:
+    parsed = urlparse(site_url)
+    if not parsed.scheme or not parsed.netloc:
+        return []
+
+    origin = f"{parsed.scheme}://{parsed.netloc}/"
+    base = site_url.rstrip("/") + "/"
+
+    candidates = [urljoin(base, "searchindex.js")]
+    if base != origin:
+        candidates.append(urljoin(origin, "searchindex.js"))
+
+    seen: set[str] = set()
+    unique: List[str] = []
+    for item in candidates:
+        if item not in seen:
+            unique.append(item)
+            seen.add(item)
+    return unique
+
+
+def _sphinx_base_from_index_url(index_url: str) -> str:
+    if index_url.endswith("/searchindex.js"):
+        return index_url[: -len("/searchindex.js")] + "/"
+    if index_url.endswith("searchindex.js"):
+        return index_url[: -len("searchindex.js")]
+    return urljoin(index_url, "./")
+
+
+async def _fetch_bytes(
+    client: httpx.AsyncClient, url: str, *, user_agent: str, timeout_seconds: float
+) -> Optional[bytes]:
+    try:
+        response = await client.get(
+            url,
+            headers={"User-Agent": user_agent},
+            timeout=httpx.Timeout(timeout_seconds),
+            follow_redirects=True,
+        )
+        if response.status_code >= 400:
+            return None
+        return response.content
+    except Exception:
+        return None
+
+
+def _maybe_decompress_gzip(blob: bytes) -> bytes:
+    # Some sitemaps are served as *.gz without Content-Encoding headers.
+    if len(blob) >= 2 and blob[0] == 0x1F and blob[1] == 0x8B:
+        try:
+            return gzip.decompress(blob)
+        except Exception:
+            return blob
+    return blob
+
+
+def _xml_root_tag(root: ET.Element) -> str:
+    if "}" in root.tag:
+        return root.tag.split("}", 1)[1]
+    return root.tag
+
+
+def _parse_sitemap_xml(blob: bytes) -> Tuple[List[str], List[str]]:
+    """
+    Returns (urls, child_sitemaps).
+    """
+    try:
+        root = ET.fromstring(blob)
+    except Exception:
+        return [], []
+
+    tag = _xml_root_tag(root)
+    if tag == "urlset":
+        urls = [
+            (loc.text or "").strip()
+            for loc in root.findall(".//{*}url/{*}loc")
+            if (loc.text or "").strip()
+        ]
+        return urls, []
+
+    if tag == "sitemapindex":
+        sitemaps = [
+            (loc.text or "").strip()
+            for loc in root.findall(".//{*}sitemap/{*}loc")
+            if (loc.text or "").strip()
+        ]
+        return [], sitemaps
+
+    return [], []
+
+
+async def _discover_sitemaps_from_robots(
+    client: httpx.AsyncClient, site_url: str, *, user_agent: str
+) -> List[str]:
+    parsed = urlparse(site_url)
+    if not parsed.scheme or not parsed.netloc:
+        return []
+    robots_url = f"{parsed.scheme}://{parsed.netloc}/robots.txt"
+    try:
+        response = await client.get(
+            robots_url,
+            headers={"User-Agent": user_agent},
+            timeout=httpx.Timeout(10.0),
+            follow_redirects=True,
+        )
+        if response.status_code >= 400:
+            return []
+        sitemaps = []
+        for line in response.text.splitlines():
+            if line.lower().startswith("sitemap:"):
+                sitemap = line.split(":", 1)[1].strip()
+                if sitemap:
+                    sitemaps.append(sitemap)
+        return sitemaps
+    except Exception:
+        return []
+
+
+async def _load_site_sitemap_urls(
+    client: httpx.AsyncClient,
+    site_url: str,
+    *,
+    user_agent: str,
+    allow_html_fallback: bool = True,
+) -> List[str]:
+    sitemap_urls = await _discover_sitemaps_from_robots(
+        client, site_url, user_agent=user_agent
+    )
+    sitemap_urls.extend(_sitemap_candidates(site_url))
+
+    visited_sitemaps = set()
+    sitemap_queue = []
+    for sitemap_url in sitemap_urls:
+        if sitemap_url and sitemap_url not in visited_sitemaps:
+            sitemap_queue.append(sitemap_url)
+            visited_sitemaps.add(sitemap_url)
+
+    discovered_urls: List[str] = []
+    seen_urls = set()
+
+    while sitemap_queue and len(visited_sitemaps) <= _MAX_SITEMAPS_TO_FETCH:
+        sitemap_url = sitemap_queue.pop(0)
+
+        blob = await _fetch_bytes(
+            client, sitemap_url, user_agent=user_agent, timeout_seconds=15.0
+        )
+        if not blob:
+            continue
+
+        blob = _maybe_decompress_gzip(blob)
+        urls, child_sitemaps = _parse_sitemap_xml(blob)
+
+        for url in urls:
+            if url in seen_urls:
+                continue
+            seen_urls.add(url)
+            discovered_urls.append(url)
+            if len(discovered_urls) >= _MAX_SITEMAP_URLS:
+                return discovered_urls
+
+        for child in child_sitemaps:
+            if child in visited_sitemaps:
+                continue
+            if len(visited_sitemaps) >= _MAX_SITEMAPS_TO_FETCH:
+                break
+            visited_sitemaps.add(child)
+            sitemap_queue.append(child)
+
+    if discovered_urls:
+        return discovered_urls
+
+    if not allow_html_fallback:
+        return []
+
+    return await _discover_urls_from_html_links(client, site_url, user_agent=user_agent)
+
+
+async def _discover_urls_from_html_links(
+    client: httpx.AsyncClient, site_url: str, *, user_agent: str
+) -> List[str]:
+    """Discover internal links from the site's HTML when no sitemap is available."""
+    parsed = urlparse(site_url)
+    if not parsed.scheme or not parsed.netloc:
+        return []
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    base_for_join = site_url.rstrip("/") + "/"
+
+    html_blob = await _fetch_bytes(
+        client, site_url, user_agent=user_agent, timeout_seconds=15.0
+    )
+    if not html_blob:
+        return []
+
+    try:
+        html_text = html_blob.decode("utf-8", errors="ignore")
+    except Exception:
+        return []
+
+    soup = BeautifulSoup(html_text, "html.parser")
+    discovered_from_html: List[str] = []
+    seen_html_urls: set[str] = set()
+
+    def _is_asset_path(path: str) -> bool:
+        return bool(
+            re.search(
+                r"\.(?:png|jpe?g|gif|svg|webp|css|js|map|ico|woff2?|ttf|otf|eot|pdf|zip|gz)$",
+                path.lower(),
+            )
+        )
+
+    for anchor in soup.find_all("a", href=True):
+        href = str(anchor.get("href") or "").strip()
+        if not href:
+            continue
+        lower = href.lower()
+        if lower.startswith(("#", "mailto:", "javascript:", "tel:")):
+            continue
+
+        absolute = urljoin(base_for_join, href)
+        parsed_link = urlparse(absolute)
+        if parsed_link.scheme not in {"http", "https"}:
+            continue
+        if parsed_link.netloc.lower() != parsed.netloc.lower():
+            continue
+        if _is_asset_path(parsed_link.path or ""):
+            continue
+
+        sanitized = parsed_link._replace(query="", fragment="").geturl()
+        if not sanitized.startswith(origin):
+            continue
+        if sanitized in seen_html_urls:
+            continue
+        seen_html_urls.add(sanitized)
+        discovered_from_html.append(sanitized)
+        if len(discovered_from_html) >= _MAX_SITEMAP_URLS:
+            break
+
+    return discovered_from_html
+
+
+def _extract_text_snippet(text: str, tokens: Sequence[str]) -> str:
+    cleaned = re.sub(r"\s+", " ", text).strip()
+    if not cleaned:
+        return ""
+
+    if not tokens:
+        return cleaned[:240]
+
+    lower = cleaned.lower()
+    best_idx: Optional[int] = None
+    for token in tokens:
+        idx = lower.find(token)
+        if idx == -1:
+            continue
+        if best_idx is None or idx < best_idx:
+            best_idx = idx
+
+    if best_idx is None:
+        return cleaned[:240]
+
+    start = max(0, best_idx - 80)
+    end = min(len(cleaned), best_idx + 160)
+    return cleaned[start:end].strip()[:240]
+
+
+def _score_urls(urls: Iterable[str], tokens: Sequence[str]) -> List[Tuple[int, str]]:
+    scored: List[Tuple[int, str]] = []
+    if not tokens:
+        return [(1, url) for url in urls]
+
+    for url in urls:
+        url_lower = url.lower()
+        score = 0
+        for token in tokens:
+            if token not in url_lower:
+                continue
+            score += 1
+            # Boost for segment-level matches.
+            path = urlparse(url).path.lower()
+            segments = [seg for seg in re.split(r"[/._-]+", path) if seg]
+            if token in segments:
+                score += 6
+            else:
+                score += 2
+        if score > 0:
+            scored.append((score, url))
+    scored.sort(key=lambda item: (-item[0], len(item[1])))
+    return scored
+
+
+def _fallback_title_from_url(url: str) -> str:
+    parsed = urlparse(url)
+    segment = (parsed.path or "/").rstrip("/").split("/")[-1]
+    segment = re.sub(r"\.[a-z0-9]+$", "", segment, flags=re.IGNORECASE)
+    segment = segment.replace("-", " ").replace("_", " ").strip()
+    if not segment:
+        return url
+    return segment[:1].upper() + segment[1:]
+
+
+def _extract_page_snippet(soup: BeautifulSoup, tokens: Sequence[str]) -> str:
+    for meta_name in ("description", "og:description"):
+        meta = soup.find("meta", attrs={"name": meta_name}) or soup.find(
+            "meta", attrs={"property": meta_name}
+        )
+        if meta and meta.get("content"):
+            return str(meta["content"]).strip()[:240]
+
+    text = soup.get_text(" ", strip=True)
+    if not text:
+        return ""
+
+    if not tokens:
+        return text[:240]
+
+    text_lower = text.lower()
+    for token in tokens:
+        idx = text_lower.find(token)
+        if idx == -1:
+            continue
+        start = max(0, idx - 80)
+        end = min(len(text), idx + 160)
+        snippet = text[start:end].strip()
+        return snippet[:240]
+
+    return text[:240]
+
+
+async def _fetch_result_metadata(
+    client: httpx.AsyncClient, url: str, *, user_agent: str, tokens: Sequence[str]
+) -> Dict[str, str]:
+    try:
+        response = await client.get(
+            url,
+            headers={"User-Agent": user_agent},
+            timeout=httpx.Timeout(12.0),
+            follow_redirects=True,
+        )
+        if response.status_code >= 400:
+            return {"title": _fallback_title_from_url(url), "snippet": ""}
+        soup = BeautifulSoup(response.text, "html.parser")
+        title = (soup.title.string or "").strip() if soup.title else ""
+        if not title:
+            title = _fallback_title_from_url(url)
+        snippet = _extract_page_snippet(soup, tokens)
+        return {"title": title, "snippet": snippet}
+    except Exception:
+        return {"title": _fallback_title_from_url(url), "snippet": ""}
+
+
+async def _get_cached_index(
+    client: httpx.AsyncClient,
+    index_url: str,
+    *,
+    user_agent: str,
+    kind: str,
+    timeout_seconds: float,
+) -> Optional[Any]:
+    now = datetime.now()
+    cache_entry = _index_cache.get(index_url)
+    stale_payload: Optional[Any] = None
+    if cache_entry and cache_entry.kind == kind:
+        stale_payload = cache_entry.payload
+    if (
+        cache_entry
+        and cache_entry.kind == kind
+        and now - cache_entry.fetched_at <= _INDEX_CACHE_TTL
+    ):
+        return cache_entry.payload
+
+    lock = _index_locks.setdefault(index_url, asyncio.Lock())
+    async with lock:
+        cache_entry = _index_cache.get(index_url)
+        if (
+            cache_entry
+            and cache_entry.kind == kind
+            and now - cache_entry.fetched_at <= _INDEX_CACHE_TTL
+        ):
+            return cache_entry.payload
+        if cache_entry and cache_entry.kind == kind:
+            stale_payload = cache_entry.payload
+
+        blob = await _fetch_bytes(
+            client, index_url, user_agent=user_agent, timeout_seconds=timeout_seconds
+        )
+        if (not blob or len(blob) > _MAX_INDEX_BYTES) and stale_payload is not None:
+            _index_cache[index_url] = _IndexCacheEntry(
+                fetched_at=datetime.now(), kind=kind, payload=stale_payload
+            )
+            return stale_payload
+        if not blob or len(blob) > _MAX_INDEX_BYTES:
+            return None
+
+        payload: Any
+        if kind == "mkdocs":
+            try:
+                raw = json.loads(blob.decode("utf-8"))
+            except Exception:
+                if stale_payload is not None:
+                    _index_cache[index_url] = _IndexCacheEntry(
+                        fetched_at=datetime.now(), kind=kind, payload=stale_payload
+                    )
+                return stale_payload
+            docs = raw.get("docs")
+            if not isinstance(docs, list):
+                if stale_payload is not None:
+                    _index_cache[index_url] = _IndexCacheEntry(
+                        fetched_at=datetime.now(), kind=kind, payload=stale_payload
+                    )
+                return stale_payload
+
+            prepared = []
+            for doc in docs:
+                if not isinstance(doc, dict):
+                    continue
+                location = str(doc.get("location") or "").strip()
+                title = str(doc.get("title") or "").strip()
+                text = str(doc.get("text") or "").strip()
+                if len(text) > _MAX_INDEX_DOC_TEXT_CHARS:
+                    text = text[:_MAX_INDEX_DOC_TEXT_CHARS]
+                if not location:
+                    continue
+                prepared.append({"location": location, "title": title, "text": text})
+
+            payload = tuple(prepared)
+        elif kind == "sphinx":
+            try:
+                text = blob.decode("utf-8", errors="ignore")
+            except Exception:
+                if stale_payload is not None:
+                    _index_cache[index_url] = _IndexCacheEntry(
+                        fetched_at=datetime.now(), kind=kind, payload=stale_payload
+                    )
+                return stale_payload
+
+            marker = "Search.setIndex("
+            idx = text.find(marker)
+            if idx == -1:
+                if stale_payload is not None:
+                    _index_cache[index_url] = _IndexCacheEntry(
+                        fetched_at=datetime.now(), kind=kind, payload=stale_payload
+                    )
+                return stale_payload
+            start = text.find("{", idx)
+            end = text.rfind("}")
+            if start == -1 or end == -1 or end <= start:
+                if stale_payload is not None:
+                    _index_cache[index_url] = _IndexCacheEntry(
+                        fetched_at=datetime.now(), kind=kind, payload=stale_payload
+                    )
+                return stale_payload
+            json_text = text[start : end + 1]
+            try:
+                payload = json.loads(json_text)
+            except Exception:
+                if stale_payload is not None:
+                    _index_cache[index_url] = _IndexCacheEntry(
+                        fetched_at=datetime.now(), kind=kind, payload=stale_payload
+                    )
+                return stale_payload
+        else:
+            return None
+
+        _index_cache[index_url] = _IndexCacheEntry(
+            fetched_at=datetime.now(), kind=kind, payload=payload
+        )
+        return payload
+
+
+def _score_document(url: str, title: str, text: str, tokens: Sequence[str]) -> int:
+    if not tokens:
+        return 1
+
+    url_lower = url.lower()
+    title_lower = title.lower()
+    text_lower = text.lower()
+
+    score = 0
+    for token in tokens:
+        if token in title_lower:
+            score += 25
+        if token in url_lower:
+            score += 6
+        occurrences = text_lower.count(token)
+        if occurrences:
+            score += 8 + min(occurrences, 20)
+
+    return score
+
+
+async def _gather_with_limit(
+    coros: Sequence[Awaitable[Any]], *, concurrency: int
+) -> List[Any]:
+    if concurrency <= 1:
+        results: List[Any] = []
+        for coro in coros:
+            results.append(await coro)
+        return results
+
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def _runner(coro: Awaitable[Any]) -> Any:
+        async with semaphore:
+            return await coro
+
+    return await asyncio.gather(
+        *[_runner(coro) for coro in coros], return_exceptions=True
+    )
+
+
+async def _search_via_mkdocs_index(
+    site_url: str,
+    tokens: Sequence[str],
+    client: httpx.AsyncClient,
+    *,
+    user_agent: str,
+    num_results: int,
+    allow_network: bool,
+) -> Optional[List[Dict[str, str]]]:
+    for index_url in _mkdocs_index_candidates(site_url):
+        if allow_network:
+            docs = await _get_cached_index(
+                client,
+                index_url,
+                user_agent=user_agent,
+                kind="mkdocs",
+                timeout_seconds=20.0,
+            )
+        else:
+            docs = _get_cached_index_from_memory(index_url, kind="mkdocs")
+        if not docs:
+            continue
+
+        base_url = _mkdocs_base_from_index_url(index_url)
+        scored: List[Tuple[int, Dict[str, str]]] = []
+        for doc in docs:
+            location = str(doc.get("location") or "")
+            url = urljoin(base_url, location)
+            if not _matches_site_prefix(url, site_url):
+                continue
+            title = str(doc.get("title") or "") or _fallback_title_from_url(url)
+            text = str(doc.get("text") or "")
+            score = _score_document(url, title, text, tokens)
+            if score <= 0:
+                continue
+            snippet = _extract_text_snippet(text, tokens)
+            scored.append((score, {"link": url, "title": title, "snippet": snippet}))
+
+        scored.sort(key=lambda item: (-item[0], len(item[1]["link"])))
+        organic = [item[1] for item in scored[: max(num_results, 1)]]
+        if organic:
+            return organic
+
+    return None
+
+
+def _coerce_sphinx_doc_hits(entry: Any) -> List[Tuple[int, int]]:
+    """Return a list of (doc_id, weight) pairs."""
+    if not isinstance(entry, list):
+        return []
+    if not entry:
+        return []
+
+    if all(isinstance(item, int) for item in entry):
+        return [(item, 1) for item in entry]
+
+    hits: List[Tuple[int, int]] = []
+    for item in entry:
+        if isinstance(item, int):
+            hits.append((item, 1))
+            continue
+        if isinstance(item, (list, tuple)) and item and isinstance(item[0], int):
+            weight = 1
+            if len(item) > 1 and isinstance(item[1], int):
+                weight = max(item[1], 1)
+            hits.append((item[0], weight))
+    return hits
+
+
+async def _search_via_sphinx_index(
+    site_url: str,
+    tokens: Sequence[str],
+    client: httpx.AsyncClient,
+    *,
+    user_agent: str,
+    num_results: int,
+    fetch_text: Optional[Callable[[str], Awaitable[str]]],
+    fetch_text_concurrency: int,
+    allow_network: bool,
+) -> Optional[List[Dict[str, str]]]:
+    for index_url in _sphinx_index_candidates(site_url):
+        if allow_network:
+            index = await _get_cached_index(
+                client,
+                index_url,
+                user_agent=user_agent,
+                kind="sphinx",
+                timeout_seconds=20.0,
+            )
+        else:
+            index = _get_cached_index_from_memory(index_url, kind="sphinx")
+        if not isinstance(index, dict):
+            continue
+
+        filenames = index.get("filenames")
+        titles = index.get("titles")
+        terms = index.get("terms")
+        titleterms = index.get("titleterms")
+        if not (
+            isinstance(filenames, list)
+            and isinstance(titles, list)
+            and isinstance(terms, dict)
+        ):
+            continue
+
+        base_url = _sphinx_base_from_index_url(index_url)
+        scores: Dict[int, int] = {}
+        for token in tokens:
+            for doc_id, weight in _coerce_sphinx_doc_hits(terms.get(token)):
+                scores[doc_id] = scores.get(doc_id, 0) + (10 * weight)
+            if isinstance(titleterms, dict):
+                for doc_id, weight in _coerce_sphinx_doc_hits(titleterms.get(token)):
+                    scores[doc_id] = scores.get(doc_id, 0) + (20 * weight)
+
+        ranked_doc_ids = sorted(scores.items(), key=lambda item: -item[1])
+        hits: List[Tuple[int, str]] = []
+        for doc_id, _ in ranked_doc_ids:
+            if not isinstance(doc_id, int) or doc_id < 0 or doc_id >= len(filenames):
+                continue
+            url = urljoin(base_url, str(filenames[doc_id]))
+            if not _matches_site_prefix(url, site_url):
+                continue
+            hits.append((doc_id, url))
+            if len(hits) >= max(num_results, 1):
+                break
+
+        if not hits:
+            continue
+
+        urls = [url for _, url in hits]
+        snippets_by_url: Dict[str, str] = {url: "" for url in urls}
+        if allow_network and fetch_text and tokens:
+            texts = await _gather_with_limit(
+                [fetch_text(url) for url in urls], concurrency=fetch_text_concurrency
+            )
+            for url, text in zip(urls, texts):
+                if isinstance(text, Exception):
+                    continue
+                snippets_by_url[url] = _extract_text_snippet(str(text), tokens)
+        elif allow_network and tokens:
+            metadatas = await asyncio.gather(
+                *[
+                    _fetch_result_metadata(
+                        client, url, user_agent=user_agent, tokens=tokens
+                    )
+                    for url in urls
+                ],
+                return_exceptions=True,
+            )
+            for url, metadata in zip(urls, metadatas):
+                if isinstance(metadata, Exception):
+                    continue
+                snippets_by_url[url] = metadata.get("snippet", "")
+
+        organic: List[Dict[str, str]] = []
+        for doc_id, url in hits:
+            title = _fallback_title_from_url(url)
+            if doc_id < len(titles) and titles[doc_id]:
+                title = str(titles[doc_id])
+            organic.append(
+                {
+                    "link": url,
+                    "title": title,
+                    "snippet": snippets_by_url.get(url, ""),
+                }
+            )
+
+        if organic:
+            return organic
+
+    return None
+
+
+async def search_site_via_sitemap(
+    query: str,
+    client: httpx.AsyncClient,
+    *,
+    user_agent: str,
+    num_results: int = 5,
+    fetch_text: Optional[Callable[[str], Awaitable[str]]] = None,
+    fetch_text_concurrency: int = _DEFAULT_CONTENT_FETCH_CONCURRENCY,
+    allow_network: bool = True,
+) -> Dict[str, Any]:
+    """
+    Perform a Serper-free search for `site:` queries.
+
+    Returns a Serper-like payload: {"organic": [{"link","title","snippet"}, ...]}.
+    """
+    site_url, terms = _parse_site_query(query)
+    if not site_url:
+        return {"organic": []}
+
+    parsed = urlparse(site_url)
+    if not parsed.scheme or not parsed.netloc:
+        return {"organic": []}
+
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+
+    tokens = _tokenize_query(terms)
+
+    # 1) Prefer docs-native search indexes when present.
+    organic = await _search_via_mkdocs_index(
+        site_url,
+        tokens,
+        client,
+        user_agent=user_agent,
+        num_results=num_results,
+        allow_network=allow_network,
+    )
+    if not organic:
+        organic = await _search_via_sphinx_index(
+            site_url,
+            tokens,
+            client,
+            user_agent=user_agent,
+            num_results=num_results,
+            fetch_text=fetch_text,
+            fetch_text_concurrency=fetch_text_concurrency,
+            allow_network=allow_network,
+        )
+    if organic:
+        return {"organic": organic}
+
+    # 2) Fallback: sitemap discovery + ranking.
+    cached_urls = _get_cached_sitemap_urls_from_memory(origin, allow_stale=False)
+    if cached_urls is not None:
+        all_urls = cached_urls
+    else:
+        if not allow_network:
+            stale_cached = _get_cached_sitemap_urls_from_memory(
+                origin, allow_stale=True
+            )
+            if stale_cached is None:
+                return {"organic": []}
+            all_urls = stale_cached
+        else:
+            lock = _sitemap_locks.setdefault(origin, asyncio.Lock())
+            async with lock:
+                cached_urls = _get_cached_sitemap_urls_from_memory(
+                    origin, allow_stale=False
+                )
+                if cached_urls is not None:
+                    all_urls = cached_urls
+                else:
+                    loaded = await _load_site_sitemap_urls(
+                        client,
+                        site_url,
+                        user_agent=user_agent,
+                        allow_html_fallback=False,
+                    )
+                    if loaded:
+                        _sitemap_cache[origin] = _SitemapCacheEntry(
+                            fetched_at=datetime.now(), urls=tuple(loaded)
+                        )
+                        all_urls = loaded
+                    else:
+                        stale_cached = _get_cached_sitemap_urls_from_memory(
+                            origin, allow_stale=True
+                        )
+                        if stale_cached is not None:
+                            existing = _sitemap_cache.get(origin)
+                            if existing and existing.urls:
+                                _sitemap_cache[origin] = _SitemapCacheEntry(
+                                    fetched_at=datetime.now(), urls=existing.urls
+                                )
+                            all_urls = stale_cached
+                        else:
+                            discovered = await _discover_urls_from_html_links(
+                                client, site_url, user_agent=user_agent
+                            )
+                            if not discovered:
+                                return {"organic": []}
+                            _sitemap_cache[origin] = _SitemapCacheEntry(
+                                fetched_at=datetime.now(), urls=tuple(discovered)
+                            )
+                            all_urls = discovered
+
+    candidates = [u for u in all_urls if _matches_site_prefix(u, site_url)]
+    scored = _score_urls(candidates, tokens)
+
+    # Preselect candidates (URL-based), then optionally rescore using page text.
+    preselect_limit = min(12, max(6, max(num_results, 1) * 2))
+    if scored:
+        preselect_urls = [url for _, url in scored[:preselect_limit]]
+        url_scores = {url: score for score, url in scored[:preselect_limit]}
+    else:
+        preselect_urls = sorted(candidates, key=len)[:preselect_limit]
+        url_scores = {url: 0 for url in preselect_urls}
+
+    if fetch_text and tokens and preselect_urls:
+        texts = await _gather_with_limit(
+            [fetch_text(url) for url in preselect_urls],
+            concurrency=fetch_text_concurrency,
+        )
+        rescored: List[Tuple[int, str, str, str]] = []
+        for url, text in zip(preselect_urls, texts):
+            title = _fallback_title_from_url(url)
+            if isinstance(text, Exception):
+                rescored.append((url_scores.get(url, 0), url, title, ""))
+                continue
+            snippet = _extract_text_snippet(str(text), tokens)
+            content_score = _score_document(url, title, str(text), tokens)
+            total = url_scores.get(url, 0) + content_score
+            rescored.append((total, url, title, snippet))
+
+        rescored.sort(key=lambda item: (-item[0], len(item[1])))
+        organic = [
+            {"link": url, "title": title, "snippet": snippet}
+            for _, url, title, snippet in rescored[: max(num_results, 1)]
+        ]
+        return {"organic": organic}
+
+    top_urls = preselect_urls[: max(num_results, 1)]
+    if not top_urls:
+        return {"organic": []}
+
+    if not allow_network:
+        return {
+            "organic": [
+                {"link": url, "title": _fallback_title_from_url(url), "snippet": ""}
+                for url in top_urls
+            ]
+        }
+
+    tasks = [
+        _fetch_result_metadata(client, url, user_agent=user_agent, tokens=tokens)
+        for url in top_urls
+    ]
+    metadatas = await asyncio.gather(*tasks, return_exceptions=True)
+
+    organic: List[Dict[str, str]] = []
+    for url, metadata in zip(top_urls, metadatas):
+        if isinstance(metadata, Exception):
+            organic.append(
+                {
+                    "link": url,
+                    "title": _fallback_title_from_url(url),
+                    "snippet": "",
+                }
+            )
+        else:
+            organic.append(
+                {
+                    "link": url,
+                    "title": metadata.get("title", _fallback_title_from_url(url)),
+                    "snippet": metadata.get("snippet", ""),
+                }
+            )
+
+    return {"organic": organic}

--- a/src/documentation_search_enhanced/snyk_integration.py
+++ b/src/documentation_search_enhanced/snyk_integration.py
@@ -184,12 +184,18 @@ class SnykIntegration:
                 test_payload = {
                     "encoding": "plain",
                     "files": {
-                        "requirements.txt"
-                        if snyk_ecosystem == "pip"
-                        else "package.json": {
-                            "contents": f"{package_name}=={version}"
+                        (
+                            "requirements.txt"
                             if snyk_ecosystem == "pip"
-                            else json.dumps({"dependencies": {package_name: version}})
+                            else "package.json"
+                        ): {
+                            "contents": (
+                                f"{package_name}=={version}"
+                                if snyk_ecosystem == "pip"
+                                else json.dumps(
+                                    {"dependencies": {package_name: version}}
+                                )
+                            )
                         }
                     },
                 }

--- a/src/documentation_search_enhanced/web_scraper.py
+++ b/src/documentation_search_enhanced/web_scraper.py
@@ -7,6 +7,7 @@ import sys
 from typing import Optional
 
 from bs4 import BeautifulSoup
+import httpx
 from playwright.async_api import Browser, async_playwright
 
 
@@ -15,12 +16,26 @@ class PlaywrightScraper:
 
     _browser: Optional[Browser] = None
     _playwright = None
+    _disabled_reason: Optional[str] = None
 
     async def _get_browser(self) -> Browser:
         """Initializes and returns a shared browser instance."""
+        if self._disabled_reason:
+            raise RuntimeError(self._disabled_reason)
         if self._browser is None or not self._browser.is_connected():
-            self._playwright = await async_playwright().start()
-            self._browser = await self._playwright.chromium.launch()
+            try:
+                self._playwright = await async_playwright().start()
+                self._browser = await self._playwright.chromium.launch()
+            except Exception as e:
+                self._disabled_reason = f"Playwright disabled: {e}"
+                if self._playwright:
+                    try:
+                        await self._playwright.stop()
+                    except Exception:
+                        pass
+                    self._playwright = None
+                self._browser = None
+                raise
         return self._browser
 
     async def scrape_url(self, url: str) -> str:
@@ -30,10 +45,15 @@ class PlaywrightScraper:
         This method can handle dynamic content, as it waits for the page
         to fully load and can execute scripts if needed.
         """
-        browser = await self._get_browser()
-        page = await browser.new_page()
+        page = None
 
         try:
+            if self._disabled_reason:
+                return await self._scrape_url_fallback(url)
+
+            browser = await self._get_browser()
+            page = await browser.new_page()
+
             # Navigate to the page and wait for it to be fully loaded
             await page.goto(url, wait_until="networkidle", timeout=60000)
 
@@ -59,9 +79,32 @@ class PlaywrightScraper:
 
         except Exception as e:
             print(f"Failed to scrape {url}: {e}", file=sys.stderr)
-            return f"Error: Could not retrieve content from {url}."
+            return await self._scrape_url_fallback(url)
         finally:
-            await page.close()
+            if page is not None:
+                await page.close()
+
+    async def _scrape_url_fallback(self, url: str) -> str:
+        """Fallback fetcher when Playwright cannot launch (e.g., sandboxed environments)."""
+        headers = {"User-Agent": "docs-app/1.0"}
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(15.0, read=30.0),
+                follow_redirects=True,
+                headers=headers,
+            ) as client:
+                response = await client.get(url)
+                response.raise_for_status()
+
+            soup = BeautifulSoup(response.text, "html.parser")
+            for element in soup(
+                ["script", "style", "nav", "footer", "header", "aside"]
+            ):
+                element.decompose()
+            return soup.get_text(separator=" ", strip=True)
+        except Exception as e:
+            print(f"Fallback fetch failed for {url}: {e}", file=sys.stderr)
+            return f"Error: Could not retrieve content from {url}."
 
     async def close(self):
         """Closes the browser instance."""

--- a/test_instructions.md
+++ b/test_instructions.md
@@ -38,7 +38,6 @@ uvx documentation-search-enhanced@latest
       "command": "uvx",
       "args": ["--from", "/Users/antonmishel/workspace/documentation-search-mcp", "documentation-search-enhanced"],
       "env": {
-        "SERPER_API_KEY": "your-serper-api-key-here",
         "ENVIRONMENT": "development"
       }
     }
@@ -161,7 +160,6 @@ Add to your `.cursorrules` or Cursor settings:
       "args": ["--from", ".", "documentation-search-enhanced"],
       "cwd": "/Users/antonmishel/workspace/documentation-search-mcp",
       "env": {
-        "SERPER_API_KEY": "your-key-here",
         "ENVIRONMENT": "development"
       }
     }
@@ -248,8 +246,8 @@ await get_docs("rules plugins", "eslint")
 
 ## Troubleshooting
 
-### SERPER_API_KEY not set
-If you see warnings about SERPER_API_KEY, set it:
+### Optional: Serper-powered search
+If you want Serper-powered search, set:
 ```bash
 export SERPER_API_KEY="your-key-here"
 ```

--- a/test_site_index_builder.py
+++ b/test_site_index_builder.py
@@ -1,0 +1,95 @@
+import json
+
+import httpx
+import pytest
+
+from documentation_search_enhanced.site_index_builder import (
+    SiteIndexBuildSettings,
+    build_site_index_file,
+)
+from documentation_search_enhanced import site_search
+
+
+@pytest.mark.asyncio
+async def test_build_site_index_file_writes_indexes_and_missing_sitemaps(
+    tmp_path, monkeypatch
+):
+    mkdocs_site = "https://mkdocs.example.com/docs/"
+    sphinx_site = "https://sphinx.example.com/"
+    noindex_site = "https://noindex.example.com/"
+
+    mkdocs_index_url = "https://mkdocs.example.com/docs/search/search_index.json"
+    sphinx_index_url = "https://sphinx.example.com/searchindex.js"
+
+    mkdocs_blob = json.dumps(
+        {
+            "docs": [
+                {
+                    "location": "reference/authentication/",
+                    "title": "Authentication",
+                    "text": "Authentication middleware reference and examples.",
+                }
+            ]
+        }
+    ).encode("utf-8")
+    sphinx_blob = (
+        'Search.setIndex({"filenames":["ref/auth.html"],'
+        '"titles":["Authentication"],'
+        '"terms":{"authentication":[0]}})'
+    ).encode("utf-8")
+
+    async def fake_fetch_bytes(
+        client: httpx.AsyncClient,
+        url: str,
+        *,
+        user_agent: str,
+        timeout_seconds: float,
+    ):
+        if url == mkdocs_index_url:
+            return mkdocs_blob
+        if url == sphinx_index_url:
+            return sphinx_blob
+        return None
+
+    calls = {"sitemaps": 0}
+
+    async def fake_load_site_sitemap_urls(
+        client: httpx.AsyncClient, site_url: str, *, user_agent: str
+    ):
+        calls["sitemaps"] += 1
+        assert site_url == noindex_site
+        return [f"{noindex_site}guide/authentication/"]
+
+    monkeypatch.setattr(site_search, "_fetch_bytes", fake_fetch_bytes)
+    monkeypatch.setattr(
+        site_search, "_load_site_sitemap_urls", fake_load_site_sitemap_urls
+    )
+
+    output = tmp_path / "docs_site_index.json"
+    result = await build_site_index_file(
+        {
+            "mkdocs": mkdocs_site,
+            "sphinx": sphinx_site,
+            "noindex": noindex_site,
+        },
+        output_path=str(output),
+        gzip_output=False,
+        settings=SiteIndexBuildSettings(
+            user_agent="tests",
+            sitemap_mode="missing",
+            max_sitemap_urls=100,
+            max_concurrent_sites=2,
+        ),
+    )
+
+    assert result["status"] == "ok"
+    assert result["indexed_libraries"] == 3
+    assert calls["sitemaps"] == 1
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    assert mkdocs_index_url in payload["indexes"]
+    assert sphinx_index_url in payload["indexes"]
+    assert payload["sitemaps"]["https://noindex.example.com"]["urls"] == [
+        f"{noindex_site}guide/authentication/"
+    ]

--- a/test_site_index_downloader.py
+++ b/test_site_index_downloader.py
@@ -1,0 +1,114 @@
+import gzip
+import json
+import os
+import time
+
+import httpx
+import pytest
+
+from documentation_search_enhanced import site_index_downloader
+
+
+@pytest.mark.asyncio
+async def test_download_site_index_downloads_and_writes_decompressed_json(tmp_path):
+    payload = {
+        "schema_version": 1,
+        "generated_at": "2025-01-01T00:00:00",
+        "sitemaps": {},
+        "indexes": {},
+    }
+    gz_blob = gzip.compress(json.dumps(payload).encode("utf-8"))
+    url = "https://example.com/docs_site_index.json.gz"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == url
+        return httpx.Response(200, content=gz_blob)
+
+    dest_path = tmp_path / "docs_site_index.json"
+    transport = httpx.MockTransport(handler)
+
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await site_index_downloader.download_site_index(
+            client,
+            urls=(url,),
+            dest_path=str(dest_path),
+            user_agent="tests",
+        )
+
+    assert result["status"] == "downloaded"
+    assert dest_path.exists()
+    stored = json.loads(dest_path.read_text(encoding="utf-8"))
+    assert stored["schema_version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_download_site_index_falls_back_to_second_url_on_404(tmp_path):
+    payload = {
+        "schema_version": 1,
+        "generated_at": "2025-01-01T00:00:00",
+        "sitemaps": {},
+        "indexes": {},
+    }
+    blob = json.dumps(payload).encode("utf-8")
+    first = "https://example.com/missing.json.gz"
+    second = "https://example.com/docs_site_index.json"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == first:
+            return httpx.Response(404)
+        assert str(request.url) == second
+        return httpx.Response(200, content=blob)
+
+    dest_path = tmp_path / "docs_site_index.json"
+    transport = httpx.MockTransport(handler)
+
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await site_index_downloader.download_site_index(
+            client,
+            urls=(first, second),
+            dest_path=str(dest_path),
+            user_agent="tests",
+        )
+
+    assert result["status"] == "downloaded"
+    assert result["url"] == second
+    assert dest_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_ensure_site_index_file_skips_when_up_to_date(tmp_path):
+    dest_path = tmp_path / "docs_site_index.json"
+    dest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "generated_at": "2025-01-01T00:00:00",
+                "sitemaps": {},
+                "indexes": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    now = time.time()
+    os.utime(dest_path, (now, now))
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        raise AssertionError("Network should not be called when index is up to date")
+
+    transport = httpx.MockTransport(handler)
+    settings = site_index_downloader.SiteIndexDownloadSettings(
+        path=str(dest_path),
+        urls=("https://example.com/should-not-fetch.json",),
+        auto_download=True,
+        max_age_hours=24 * 7,
+    )
+
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await site_index_downloader.ensure_site_index_file(
+            client,
+            settings=settings,
+            user_agent="tests",
+        )
+
+    assert result["status"] == "ok"
+    assert result["path"] == str(dest_path)

--- a/test_site_search.py
+++ b/test_site_search.py
@@ -1,0 +1,323 @@
+from datetime import datetime, timedelta
+
+import httpx
+import pytest
+
+from documentation_search_enhanced import site_search
+
+
+@pytest.mark.asyncio
+async def test_search_site_via_sitemap_ranks_and_caches(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls = {"loads": 0}
+
+    async def fake_search_via_mkdocs_index(*args, **kwargs):
+        return None
+
+    async def fake_search_via_sphinx_index(*args, **kwargs):
+        return None
+
+    async def fake_load_site_sitemap_urls(
+        client: httpx.AsyncClient,
+        site_url: str,
+        *,
+        user_agent: str,
+        allow_html_fallback: bool = True,
+    ):
+        _ = allow_html_fallback
+        calls["loads"] += 1
+        return [
+            "https://docs.example.com/reference/authentication/middleware/",
+            "https://docs.example.com/reference/authentication/",
+            "https://docs.example.com/reference/middleware/",
+            "https://docs.example.com/reference/intro/",
+            "https://docs.example.com/guide/authentication/middleware/",
+            "https://other.example.com/reference/authentication/middleware/",
+        ]
+
+    async def fake_fetch_result_metadata(
+        client: httpx.AsyncClient, url: str, *, user_agent: str, tokens
+    ):
+        return {"title": f"Title {url}", "snippet": "Example snippet"}
+
+    monkeypatch.setattr(
+        site_search, "_search_via_mkdocs_index", fake_search_via_mkdocs_index
+    )
+    monkeypatch.setattr(
+        site_search, "_search_via_sphinx_index", fake_search_via_sphinx_index
+    )
+    monkeypatch.setattr(
+        site_search, "_load_site_sitemap_urls", fake_load_site_sitemap_urls
+    )
+    monkeypatch.setattr(
+        site_search, "_fetch_result_metadata", fake_fetch_result_metadata
+    )
+    site_search._sitemap_cache.clear()
+    site_search._sitemap_locks.clear()
+    site_search._index_cache.clear()
+    site_search._index_locks.clear()
+
+    query = "site:https://docs.example.com/reference/ authentication middleware"
+
+    async with httpx.AsyncClient() as client:
+        result = await site_search.search_site_via_sitemap(
+            query, client, user_agent="tests", num_results=3
+        )
+        links = [item["link"] for item in result["organic"]]
+        assert (
+            links[0] == "https://docs.example.com/reference/authentication/middleware/"
+        )
+        assert sorted(links[1:]) == sorted(
+            [
+                "https://docs.example.com/reference/authentication/",
+                "https://docs.example.com/reference/middleware/",
+            ]
+        )
+        assert calls["loads"] == 1
+
+        # Second call should hit in-memory sitemap cache.
+        _ = await site_search.search_site_via_sitemap(
+            query, client, user_agent="tests", num_results=3
+        )
+        assert calls["loads"] == 1
+
+
+@pytest.mark.asyncio
+async def test_search_site_via_sitemap_requires_site():
+    async with httpx.AsyncClient() as client:
+        result = await site_search.search_site_via_sitemap(
+            "authentication middleware", client, user_agent="tests", num_results=3
+        )
+    assert result == {"organic": []}
+
+
+@pytest.mark.asyncio
+async def test_load_site_sitemap_urls_falls_back_to_html_links(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def fake_discover_sitemaps_from_robots(*_args, **_kwargs):
+        return []
+
+    async def fake_fetch_bytes(
+        client: httpx.AsyncClient,
+        url: str,
+        *,
+        user_agent: str,
+        timeout_seconds: float,
+    ):
+        _ = client, user_agent, timeout_seconds
+        if "sitemap" in url:
+            return None
+        if url == "https://react.dev/reference/react":
+            return b'<html><body><a href="/reference/react/components">Components</a></body></html>'
+        return None
+
+    monkeypatch.setattr(
+        site_search,
+        "_discover_sitemaps_from_robots",
+        fake_discover_sitemaps_from_robots,
+    )
+    monkeypatch.setattr(site_search, "_fetch_bytes", fake_fetch_bytes)
+
+    async with httpx.AsyncClient() as client:
+        urls = await site_search._load_site_sitemap_urls(
+            client, "https://react.dev/reference/react", user_agent="tests"
+        )
+
+    assert "https://react.dev/reference/react/components" in urls
+
+
+@pytest.mark.asyncio
+async def test_search_site_prefers_mkdocs_index(monkeypatch: pytest.MonkeyPatch):
+    async def fake_get_cached_index(
+        client: httpx.AsyncClient,
+        index_url: str,
+        *,
+        user_agent: str,
+        kind: str,
+        timeout_seconds: float,
+    ):
+        assert kind == "mkdocs"
+        return (
+            {
+                "location": "reference/authentication/middleware/",
+                "title": "Auth Middleware",
+                "text": "Authentication middleware reference and examples.",
+            },
+            {
+                "location": "reference/intro/",
+                "title": "Intro",
+                "text": "Welcome to the docs.",
+            },
+        )
+
+    async def should_not_call_sitemap(*args, **kwargs):
+        raise AssertionError("Sitemap fallback should not be called when index exists")
+
+    monkeypatch.setattr(
+        site_search,
+        "_mkdocs_index_candidates",
+        lambda _: ["https://docs.example.com/search/search_index.json"],
+    )
+    monkeypatch.setattr(
+        site_search,
+        "_mkdocs_base_from_index_url",
+        lambda _: "https://docs.example.com/",
+    )
+    monkeypatch.setattr(site_search, "_get_cached_index", fake_get_cached_index)
+    monkeypatch.setattr(site_search, "_load_site_sitemap_urls", should_not_call_sitemap)
+
+    async with httpx.AsyncClient() as client:
+        result = await site_search.search_site_via_sitemap(
+            "site:https://docs.example.com/reference/ authentication middleware",
+            client,
+            user_agent="tests",
+            num_results=2,
+        )
+
+    assert [item["link"] for item in result["organic"]] == [
+        "https://docs.example.com/reference/authentication/middleware/",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_site_uses_sphinx_index_and_snippets(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def fake_get_cached_index(
+        client: httpx.AsyncClient,
+        index_url: str,
+        *,
+        user_agent: str,
+        kind: str,
+        timeout_seconds: float,
+    ):
+        assert kind == "sphinx"
+        return {
+            "filenames": ["ref/auth.html", "ref/middleware.html"],
+            "titles": ["Authentication", "Middleware"],
+            "terms": {
+                "authentication": [0],
+                "middleware": [1],
+            },
+        }
+
+    async def fake_fetch_text(url: str) -> str:
+        return f"{url} Authentication middleware details and examples."
+
+    async def fake_search_via_mkdocs_index(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        site_search, "_search_via_mkdocs_index", fake_search_via_mkdocs_index
+    )
+    monkeypatch.setattr(
+        site_search,
+        "_sphinx_index_candidates",
+        lambda _: ["https://docs.example.com/searchindex.js"],
+    )
+    monkeypatch.setattr(
+        site_search,
+        "_sphinx_base_from_index_url",
+        lambda _: "https://docs.example.com/",
+    )
+    monkeypatch.setattr(site_search, "_get_cached_index", fake_get_cached_index)
+
+    async with httpx.AsyncClient() as client:
+        result = await site_search.search_site_via_sitemap(
+            "site:https://docs.example.com/ref/ authentication middleware",
+            client,
+            user_agent="tests",
+            num_results=2,
+            fetch_text=fake_fetch_text,
+        )
+
+    assert result["organic"][0]["link"] == "https://docs.example.com/ref/auth.html"
+    assert result["organic"][0]["title"] == "Authentication"
+    assert "authentication" in result["organic"][0]["snippet"].lower()
+
+
+@pytest.mark.asyncio
+async def test_preindexed_state_roundtrip_offline(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    site_search._sitemap_cache.clear()
+    site_search._sitemap_locks.clear()
+    site_search._index_cache.clear()
+    site_search._index_locks.clear()
+
+    origin = "https://docs.example.com"
+    site_search._sitemap_cache[origin] = site_search._SitemapCacheEntry(
+        fetched_at=datetime.now() - timedelta(days=365),
+        urls=(
+            "https://docs.example.com/reference/authentication/middleware/",
+            "https://docs.example.com/reference/authentication/",
+        ),
+    )
+
+    persist_path = tmp_path / "preindex.json"
+    site_search.save_preindexed_state(str(persist_path))
+
+    site_search._sitemap_cache.clear()
+    assert site_search.load_preindexed_state(str(persist_path)) is True
+
+    async def should_not_fetch(*args, **kwargs):
+        raise AssertionError("Should not fetch sitemap in offline mode when cached")
+
+    monkeypatch.setattr(site_search, "_load_site_sitemap_urls", should_not_fetch)
+
+    async with httpx.AsyncClient() as client:
+        result = await site_search.search_site_via_sitemap(
+            "site:https://docs.example.com/reference/ authentication middleware",
+            client,
+            user_agent="tests",
+            num_results=2,
+            allow_network=False,
+        )
+
+    assert [item["link"] for item in result["organic"]] == [
+        "https://docs.example.com/reference/authentication/middleware/",
+        "https://docs.example.com/reference/authentication/",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_offline_mkdocs_index_avoids_network(monkeypatch: pytest.MonkeyPatch):
+    site_search._sitemap_cache.clear()
+    site_search._sitemap_locks.clear()
+    site_search._index_cache.clear()
+    site_search._index_locks.clear()
+
+    site_url = "https://docs.example.com/reference/"
+    index_url = "https://docs.example.com/reference/search/search_index.json"
+    site_search._index_cache[index_url] = site_search._IndexCacheEntry(
+        fetched_at=datetime.now(),
+        kind="mkdocs",
+        payload=(
+            {
+                "location": "authentication/middleware/",
+                "title": "Authentication middleware",
+                "text": "Authentication middleware reference and examples.",
+            },
+        ),
+    )
+
+    async def should_not_fetch(*args, **kwargs):
+        raise AssertionError("Should not fetch MkDocs index in offline mode")
+
+    monkeypatch.setattr(site_search, "_fetch_bytes", should_not_fetch)
+
+    async with httpx.AsyncClient() as client:
+        result = await site_search.search_site_via_sitemap(
+            f"site:{site_url} authentication middleware",
+            client,
+            user_agent="tests",
+            num_results=1,
+            allow_network=False,
+        )
+
+    assert (
+        result["organic"][0]["link"]
+        == "https://docs.example.com/reference/authentication/middleware/"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -280,7 +280,7 @@ wheels = [
 
 [[package]]
 name = "documentation-search-enhanced"
-version = "1.3.2"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Make SERPER_API_KEY optional; ship prebuilt docs index auto-download + release builder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Serper-free docs search (MkDocs/Sphinx/sitemap with HTML fallback), auto-downloaded prebuilt index and CI release assets, a preindexing tool, scraper fallback, tests, and docs for v1.5.0.
> 
> - **Core search/runtime**:
>   - Introduces `site_search` (MkDocs/Sphinx index parsing, sitemap discovery, HTML link fallback) and integrates it as the default when `SERPER_API_KEY` is unset.
>   - Adds prebuilt docs index auto-download (`site_index_downloader`) at startup; controlled via `DOCS_SITE_INDEX_*` envs.
>   - New MCP tool `preindex_docs` to cache and persist site indexes.
>   - Improves server startup with lifespan task/heartbeat; refactors config loading logs.
>   - Web scraper now falls back to `httpx` if Playwright cannot launch.
> - **Release/CI**:
>   - Adds workflow `.github/workflows/build-site-index.yml` to build `docs_site_index.json(.gz)` and upload as release assets; supports manual runs (artifact upload).
>   - New `site_index_builder` module to generate the prebuilt index.
> - **Tests**:
>   - Adds `test_site_search.py`, `test_site_index_builder.py`, `test_site_index_downloader.py`; updates `conftest.py` and `test_project_scanner.py` to be self-contained.
> - **Docs & config**:
>   - Updates README/samples/AGENTS/CONTRIBUTING/CHANGELOG to document optional Serper usage, env vars, and workflows.
>   - Bumps version to `1.5.0`; updates project URLs; adds pytest config; extends `.gitignore` for generated index files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3adffb18a17a6974b861153977a3982eac938be5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->