### PR TITLE
fix(ci): release validation version parse

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Extract version from pyproject.toml
         id: package-version
         run: |
-          PACKAGE_VERSION=$(grep -oP '^version = "\K[^"]+' pyproject.toml)
+          # Extract the [project] version without accidentally matching other keys
+          # like "minversion" (pytest), which would corrupt $GITHUB_ENV.
+          # Allow leading whitespace since TOML permits indentation.
+          PACKAGE_VERSION=$(grep -m1 -oP '^\s*version\s*=\s*"\K[^"]+' pyproject.toml)
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
           echo "Package version: $PACKAGE_VERSION"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,8 @@ jobs:
         id: package-version
         run: |
           # Extract the [project] version without accidentally matching other keys
-          # like "minversion" (pytest), which would corrupt $GITHUB_ENV.
-          # Allow leading whitespace since TOML permits indentation.
+          # like "minversion" (pytest), which would corrupt $GITHUB_ENV. Allow
+          # leading whitespace since TOML permits indentation.
           PACKAGE_VERSION=$(grep -m1 -oP '^\s*version\s*=\s*"\K[^"]+' pyproject.toml)
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
           echo "Package version: $PACKAGE_VERSION"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ## Build, Test, and Development Commands
 - Install deps: `uv sync` (includes dev extras).
-- Run MCP server: `uv run python src/documentation_search_enhanced/main.py` (optional: set `SERPER_API_KEY` for Serper-powered search).
+- Run MCP server: `uv run python -m documentation_search_enhanced.main` (optional: set `SERPER_API_KEY` for Serper-powered search).
 - Test: `uv run pytest`.
 - Lint/format: `uv run ruff check src`, `uv run black src`.
 - Build/publish: `uv build`, `publish_to_pypi.sh`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ The easiest way to contribute! Add support for new documentation sources:
 
 2. **Test it works:**
 ```bash
-python src/documentation_search_enhanced/main.py
+uv run python -m documentation_search_enhanced.main
 # Test search functionality
 ```
 
@@ -79,7 +79,7 @@ uv sync
 # echo "SERPER_API_KEY=your_key_here" > .env
 
 # 4. Test the setup
-python src/documentation_search_enhanced/main.py
+uv run python -m documentation_search_enhanced.main
 # Press Ctrl+C when you see it waiting for input ✅
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ codex mcp add documentation-search-enhanced \
 To run from a local checkout instead:
 ```bash
 codex mcp add documentation-search-enhanced \
-  -- uv run python src/documentation_search_enhanced/main.py
+  -- bash -lc 'cd /path/to/documentation-search-mcp && uv run python -m documentation_search_enhanced.main'
 ```
 
 ## Development Workflow
@@ -55,7 +55,7 @@ cd documentation-search-mcp
 uv sync --all-extras --all-groups  # include dev tools
 # Optional: enable Serper-powered search
 # echo "SERPER_API_KEY=your_key_here" > .env
-uv run python src/documentation_search_enhanced/main.py
+uv run python -m documentation_search_enhanced.main
 ```
 - Run core tests: `uv run pytest --ignore=pytest-test-project`.
 - Run example FastAPI tests: `cd pytest-test-project && uv run --all-extras python -m pytest -q`.


### PR DESCRIPTION
Also update docs to run the server via -m so local installs work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Harden release workflow’s version extraction and update docs to run the server via `python -m` (including Codex local setup).
> 
> - **CI/CD (release workflow)**:
>   - Improve `pyproject.toml` version parsing to match only the `[project]` `version` key (`grep -m1 -oP '^\s*version\s*=\s*"\K[^"]+'`).
> - **Docs**:
>   - Switch local run commands to `uv run python -m documentation_search_enhanced.main` in `AGENTS.md`, `CONTRIBUTING.md`, and `README.md`.
>   - Update Codex local setup to use a `bash -lc` command with `cd` and `python -m`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7da771a11ccd85dddb5448aaa4b34fa3cf457d25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->